### PR TITLE
Add Telegram handle as a required contact detail

### DIFF
--- a/src/seedu/addressbook/AddressBook.java
+++ b/src/seedu/addressbook/AddressBook.java
@@ -974,18 +974,20 @@ public class AddressBook {
     }
 
     /**
-     * Returns true if person data (email, name, phone etc) can be extracted from the argument string.
-     * Format is [name] p/[phone] e/[email], phone and email positions can be swapped.
+     * Returns true if person data (email, name, phone, telegram etc) can be extracted from the argument string.
+     * Format is [name] p/[phone] e/[email] t/[telegram], phone, email and telegram positions can be swapped.
      *
      * @param personData person string representation
      */
     private static boolean isPersonDataExtractableFrom(String personData) {
-        final String matchAnyPersonDataPrefix = PERSON_DATA_PREFIX_PHONE + '|' + PERSON_DATA_PREFIX_EMAIL;
+        final String matchAnyPersonDataPrefix = PERSON_DATA_PREFIX_PHONE + '|' + PERSON_DATA_PREFIX_EMAIL + '|'
+                                             + PERSON_DATA_PREFIX_TELE;
         final String[] splitArgs = personData.trim().split(matchAnyPersonDataPrefix);
-        return splitArgs.length == 3 // 3 arguments
+        return splitArgs.length == 4 // 3 arguments
                 && !splitArgs[0].isEmpty() // non-empty arguments
                 && !splitArgs[1].isEmpty()
-                && !splitArgs[2].isEmpty();
+                && !splitArgs[2].isEmpty()
+                && !splitArgs[3].isEmpty();
     }
 
     /**

--- a/src/seedu/addressbook/AddressBook.java
+++ b/src/seedu/addressbook/AddressBook.java
@@ -148,11 +148,12 @@ public class AddressBook {
     private static final int PERSON_DATA_INDEX_NAME = 0;
     private static final int PERSON_DATA_INDEX_PHONE = 1;
     private static final int PERSON_DATA_INDEX_EMAIL = 2;
+    private static final int PERSON_DATA_INDEX_TELE = 3;
 
     /**
      * The number of data elements for a single person.
      */
-    private static final int PERSON_DATA_COUNT = 3;
+    private static final int PERSON_DATA_COUNT = 4;
 
     /**
      * Offset required to convert between 1-indexing and 0-indexing.COMMAND_

--- a/src/seedu/addressbook/AddressBook.java
+++ b/src/seedu/addressbook/AddressBook.java
@@ -1102,7 +1102,8 @@ public class AddressBook {
     private static boolean isPersonDataValid(String[] person) {
         return isPersonNameValid(person[PERSON_DATA_INDEX_NAME])
                 && isPersonPhoneValid(person[PERSON_DATA_INDEX_PHONE])
-                && isPersonEmailValid(person[PERSON_DATA_INDEX_EMAIL]);
+                && isPersonEmailValid(person[PERSON_DATA_INDEX_EMAIL])
+                && isPersonTeleValid(person[PERSON_DATA_INDEX_TELE]);
     }
 
     /*

--- a/src/seedu/addressbook/AddressBook.java
+++ b/src/seedu/addressbook/AddressBook.java
@@ -888,11 +888,12 @@ public class AddressBook {
      * @param email without data prefix
      * @return constructed person
      */
-    private static String[] makePersonFromData(String name, String phone, String email) {
+    private static String[] makePersonFromData(String name, String phone, String email, String tele) {
         final String[] person = new String[PERSON_DATA_COUNT];
         person[PERSON_DATA_INDEX_NAME] = name;
         person[PERSON_DATA_INDEX_PHONE] = phone;
         person[PERSON_DATA_INDEX_EMAIL] = email;
+        person[PERSON_DATA_INDEX_TELE] = tele;
         return person;
     }
 

--- a/src/seedu/addressbook/AddressBook.java
+++ b/src/seedu/addressbook/AddressBook.java
@@ -1145,6 +1145,17 @@ public class AddressBook {
         //TODO: implement a more permissive validation
     }
 
+    /**
+     * Returns true if the given string is a legal Telegram handle
+     *
+     * @param tele to be validated
+     * @return whether arg is a valid Telegram handle
+     */
+    private static boolean isPersonTeleValid(String tele) {
+        return tele.matches("@\\S+"); // Telegram handle is @[non-whitespace]
+        //TODO: implement a more permissive validation
+    }
+
 
     /*
      * ===============================================

--- a/src/seedu/addressbook/AddressBook.java
+++ b/src/seedu/addressbook/AddressBook.java
@@ -444,7 +444,10 @@ public class AddressBook {
      */
     private static String getMessageForSuccessfulAddPerson(String[] addedPerson) {
         return String.format(MESSAGE_ADDED,
-                getNameFromPerson(addedPerson), getPhoneFromPerson(addedPerson), getEmailFromPerson(addedPerson));
+                getNameFromPerson(addedPerson),
+                getPhoneFromPerson(addedPerson),
+                getEmailFromPerson(addedPerson),
+                getTeleFromPerson(addedPerson));
     }
 
     /**
@@ -674,7 +677,10 @@ public class AddressBook {
      */
     private static String getMessageForFormattedPersonData(String[] person) {
         return String.format(MESSAGE_DISPLAY_PERSON_DATA,
-                getNameFromPerson(person), getPhoneFromPerson(person), getEmailFromPerson(person));
+                getNameFromPerson(person),
+                getPhoneFromPerson(person),
+                getEmailFromPerson(person),
+                getTeleFromPerson(person));
     }
 
     /**
@@ -866,6 +872,15 @@ public class AddressBook {
     }
 
     /**
+     * Returns given person's Telegram handle
+     *
+     * @param person whose Telegram handle you want
+     */
+    private static String getTeleFromPerson(String[] person) {
+        return person[PERSON_DATA_INDEX_TELE];
+    }
+
+    /**
      * Creates a person from the given data.
      *
      * @param name of person
@@ -889,7 +904,10 @@ public class AddressBook {
      */
     private static String encodePersonToString(String[] person) {
         return String.format(PERSON_STRING_REPRESENTATION,
-                getNameFromPerson(person), getPhoneFromPerson(person), getEmailFromPerson(person));
+                getNameFromPerson(person),
+                getPhoneFromPerson(person),
+                getEmailFromPerson(person),
+                getTeleFromPerson(person));
     }
 
     /**

--- a/src/seedu/addressbook/AddressBook.java
+++ b/src/seedu/addressbook/AddressBook.java
@@ -983,7 +983,7 @@ public class AddressBook {
         final String matchAnyPersonDataPrefix = PERSON_DATA_PREFIX_PHONE + '|' + PERSON_DATA_PREFIX_EMAIL + '|'
                                              + PERSON_DATA_PREFIX_TELE;
         final String[] splitArgs = personData.trim().split(matchAnyPersonDataPrefix);
-        return splitArgs.length == 4 // 3 arguments
+        return splitArgs.length == 4 // 4 arguments
                 && !splitArgs[0].isEmpty() // non-empty arguments
                 && !splitArgs[1].isEmpty()
                 && !splitArgs[2].isEmpty()

--- a/src/seedu/addressbook/AddressBook.java
+++ b/src/seedu/addressbook/AddressBook.java
@@ -65,13 +65,13 @@ public class AddressBook {
      * at which java String.format(...) method can insert values.
      * =========================================================================
      */
-    private static final String MESSAGE_ADDED = "New person added: %1$s, Phone: %2$s, Email: %3$s";
+    private static final String MESSAGE_ADDED = "New person added: %1$s, Phone: %2$s, Email: %3$s, Telegram: %4$s";
     private static final String MESSAGE_ADDRESSBOOK_CLEARED = "Address book has been cleared!";
     private static final String MESSAGE_COMMAND_HELP = "%1$s: %2$s";
     private static final String MESSAGE_COMMAND_HELP_PARAMETERS = "\tParameters: %1$s";
     private static final String MESSAGE_COMMAND_HELP_EXAMPLE = "\tExample: %1$s";
     private static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
-    private static final String MESSAGE_DISPLAY_PERSON_DATA = "%1$s  Phone Number: %2$s  Email: %3$s";
+    private static final String MESSAGE_DISPLAY_PERSON_DATA = "%1$s  Phone Number: %2$s  Email: %3$s Telegram: %4$s";
     private static final String MESSAGE_DISPLAY_LIST_ELEMENT_INDEX = "%1$d. ";
     private static final String MESSAGE_GOODBYE = "Exiting Address Book... Good bye!";
     private static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format: %1$s " + LS + "%2$s";
@@ -94,16 +94,20 @@ public class AddressBook {
     // These are the prefix strings to define the data type of a command parameter
     private static final String PERSON_DATA_PREFIX_PHONE = "p/";
     private static final String PERSON_DATA_PREFIX_EMAIL = "e/";
+    private static final String PERSON_DATA_PREFIX_TELE = "t/";
 
     private static final String PERSON_STRING_REPRESENTATION = "%1$s " // name
                                                             + PERSON_DATA_PREFIX_PHONE + "%2$s " // phone
-                                                            + PERSON_DATA_PREFIX_EMAIL + "%3$s"; // email
+                                                            + PERSON_DATA_PREFIX_EMAIL + "%3$s" // email
+                                                            + PERSON_DATA_PREFIX_TELE + "%4$s"; // telegram handle
     private static final String COMMAND_ADD_WORD = "add";
     private static final String COMMAND_ADD_DESC = "Adds a person to the address book.";
     private static final String COMMAND_ADD_PARAMETERS = "NAME "
                                                       + PERSON_DATA_PREFIX_PHONE + "PHONE_NUMBER "
-                                                      + PERSON_DATA_PREFIX_EMAIL + "EMAIL";
-    private static final String COMMAND_ADD_EXAMPLE = COMMAND_ADD_WORD + " John Doe p/98765432 e/johnd@gmail.com";
+                                                      + PERSON_DATA_PREFIX_EMAIL + "EMAIL "
+                                                      + PERSON_DATA_PREFIX_TELE + "TELEGRAM";
+    private static final String COMMAND_ADD_EXAMPLE = COMMAND_ADD_WORD + " John Doe p/98765432 e/johnd@gmail.com "
+                                                   + "t/@johndoe";
 
     private static final String COMMAND_FIND_WORD = "find";
     private static final String COMMAND_FIND_DESC = "Finds all persons whose names contain any of the specified "

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -52,8 +52,8 @@
 || Enter command: || [Command entered:  sfdfd]
 || Invalid command format: sfdfd 
 || add: Adds a person to the address book.
-|| 	Parameters: NAME p/PHONE_NUMBER e/EMAIL
-|| 	Example: add John Doe p/98765432 e/johnd@gmail.com
+|| 	Parameters: NAME p/PHONE_NUMBER e/EMAIL t/TELEGRAM
+|| 	Example: add John Doe p/98765432 e/johnd@gmail.com t/@johndoe
 || 
 || find: Finds all persons whose names contain any of the specified keywords (case-sensitive) and displays them as a list with index numbers.
 || 	Parameters: KEYWORD [MORE_KEYWORDS]
@@ -82,94 +82,135 @@
 || Enter command: || [Command entered:  add wrong args wrong args]
 || Invalid command format: add 
 || add: Adds a person to the address book.
-|| 	Parameters: NAME p/PHONE_NUMBER e/EMAIL
-|| 	Example: add John Doe p/98765432 e/johnd@gmail.com
+|| 	Parameters: NAME p/PHONE_NUMBER e/EMAIL t/TELEGRAM
+|| 	Example: add John Doe p/98765432 e/johnd@gmail.com t/@johndoe
 || 
 || ===================================================
-|| Enter command: || [Command entered:  add Valid Name p/12345 valid@email.butNoPrefix]
+|| Enter command: || [Command entered:  add Valid Name p/12345 valid@email.butNoPrefix t/@validTele]
 || Invalid command format: add 
 || add: Adds a person to the address book.
-|| 	Parameters: NAME p/PHONE_NUMBER e/EMAIL
-|| 	Example: add John Doe p/98765432 e/johnd@gmail.com
+|| 	Parameters: NAME p/PHONE_NUMBER e/EMAIL t/TELEGRAM
+|| 	Example: add John Doe p/98765432 e/johnd@gmail.com t/@johndoe
 || 
 || ===================================================
-|| Enter command: || [Command entered:  add Valid Name 12345 e/valid@email.butPhonePrefixMissing]
+|| Enter command: || [Command entered:  add Valid Name 12345 e/valid@email.butPhonePrefixMissing t/@validTele]
 || Invalid command format: add 
 || add: Adds a person to the address book.
-|| 	Parameters: NAME p/PHONE_NUMBER e/EMAIL
-|| 	Example: add John Doe p/98765432 e/johnd@gmail.com
+|| 	Parameters: NAME p/PHONE_NUMBER e/EMAIL t/TELEGRAM
+|| 	Example: add John Doe p/98765432 e/johnd@gmail.com t/@johndoe
 || 
 || ===================================================
-|| Enter command: || [Command entered:  add []\[;] p/12345 e/valid@e.mail]
+|| Enter command: || [Command entered:  add Valid Name p/12345 e/valid@email.butTelePrefixMissing @ValidTeleButNoPrefix]
 || Invalid command format: add 
 || add: Adds a person to the address book.
-|| 	Parameters: NAME p/PHONE_NUMBER e/EMAIL
-|| 	Example: add John Doe p/98765432 e/johnd@gmail.com
+|| 	Parameters: NAME p/PHONE_NUMBER e/EMAIL t/TELEGRAM
+|| 	Example: add John Doe p/98765432 e/johnd@gmail.com t/@johndoe
 || 
 || ===================================================
-|| Enter command: || [Command entered:  add Valid Name p/not_numbers e/valid@e.mail]
+|| Enter command: || [Command entered:  add []\[;] p/12345 e/valid@e.mail t/@validTele]
 || Invalid command format: add 
 || add: Adds a person to the address book.
-|| 	Parameters: NAME p/PHONE_NUMBER e/EMAIL
-|| 	Example: add John Doe p/98765432 e/johnd@gmail.com
+|| 	Parameters: NAME p/PHONE_NUMBER e/EMAIL t/TELEGRAM
+|| 	Example: add John Doe p/98765432 e/johnd@gmail.com t/@johndoe
 || 
 || ===================================================
-|| Enter command: || [Command entered:  add Valid Name p/12345 e/notAnEmail]
+|| Enter command: || [Command entered:  add Valid Name p/not_numbers e/valid@e.mail t/@validTele]
 || Invalid command format: add 
 || add: Adds a person to the address book.
-|| 	Parameters: NAME p/PHONE_NUMBER e/EMAIL
-|| 	Example: add John Doe p/98765432 e/johnd@gmail.com
+|| 	Parameters: NAME p/PHONE_NUMBER e/EMAIL t/TELEGRAM
+|| 	Example: add John Doe p/98765432 e/johnd@gmail.com t/@johndoe
 || 
 || ===================================================
-|| Enter command: || [Command entered:  add Adam Brown p/111111 e/adam@gmail.com]
-|| New person added: Adam Brown, Phone: 111111, Email: adam@gmail.com
+|| Enter command: || [Command entered:  add Valid Name p/12345 e/notAnEmail t/@validTele]
+|| Invalid command format: add 
+|| add: Adds a person to the address book.
+|| 	Parameters: NAME p/PHONE_NUMBER e/EMAIL t/TELEGRAM
+|| 	Example: add John Doe p/98765432 e/johnd@gmail.com t/@johndoe
+|| 
+|| ===================================================
+|| Enter command: || [Command entered:  add Valid Name p/12345 e/valid@e.mail t/invalidTele]
+|| Invalid command format: add 
+|| add: Adds a person to the address book.
+|| 	Parameters: NAME p/PHONE_NUMBER e/EMAIL t/TELEGRAM
+|| 	Example: add John Doe p/98765432 e/johnd@gmail.com t/@johndoe
+|| 
+|| ===================================================
+|| Enter command: || [Command entered:  add Adam Brown p/111111 e/adam@gmail.com t/@adam_brown]
+|| New person added: Adam Brown, Phone: 111111, Email: adam@gmail.com, Telegram: @adam_brown
 || ===================================================
 || Enter command: || [Command entered:  list]
-|| 	1. Adam Brown  Phone Number: 111111  Email: adam@gmail.com
+|| 	1. Adam Brown  Phone Number: 111111  Email: adam@gmail.com Telegram: @adam_brown
 || 
 || 1 persons found!
 || ===================================================
-|| Enter command: || [Command entered:  add Betsy Choo p/222222 e/benchoo@nus.edu.sg]
-|| New person added: Betsy Choo, Phone: 222222, Email: benchoo@nus.edu.sg
+|| Enter command: || [Command entered:  add Betsy Choo p/222222 e/benchoo@nus.edu.sg t/@BetsyChoo]
+|| New person added: Betsy Choo, Phone: 222222, Email: benchoo@nus.edu.sg, Telegram: @BetsyChoo
 || ===================================================
 || Enter command: || [Command entered:  list]
-|| 	1. Adam Brown  Phone Number: 111111  Email: adam@gmail.com
-|| 	2. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg
+|| 	1. Adam Brown  Phone Number: 111111  Email: adam@gmail.com Telegram: @adam_brown
+|| 	2. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg Telegram: @BetsyChoo
 || 
 || 2 persons found!
 || ===================================================
-|| Enter command: || [Command entered:  add Charlie Dickson e/charlie.d@nus.edu.sg p/333333]
-|| New person added: Charlie Dickson, Phone: 333333, Email: charlie.d@nus.edu.sg
+|| Enter command: || [Command entered:  add Charlie Dickson p/333333 t/@charlie_dickson e/charlie.d@nus.edu.sg]
+|| New person added: Charlie Dickson, Phone: 333333, Email: charlie.d@nus.edu.sg, Telegram: @charlie_dickson
 || ===================================================
 || Enter command: || [Command entered:  list]
-|| 	1. Adam Brown  Phone Number: 111111  Email: adam@gmail.com
-|| 	2. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg
-|| 	3. Charlie Dickson  Phone Number: 333333  Email: charlie.d@nus.edu.sg
+|| 	1. Adam Brown  Phone Number: 111111  Email: adam@gmail.com Telegram: @adam_brown
+|| 	2. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg Telegram: @BetsyChoo
+|| 	3. Charlie Dickson  Phone Number: 333333  Email: charlie.d@nus.edu.sg Telegram: @charlie_dickson
 || 
 || 3 persons found!
 || ===================================================
-|| Enter command: || [Command entered:  add Dickson Ee e/dickson@nus.edu.sg p/444444]
-|| New person added: Dickson Ee, Phone: 444444, Email: dickson@nus.edu.sg
+|| Enter command: || [Command entered:  add Dickson Ee e/dickson@nus.edu.sg p/444444 t/@dickson_ee]
+|| New person added: Dickson Ee, Phone: 444444, Email: dickson@nus.edu.sg, Telegram: @dickson_ee
 || ===================================================
 || Enter command: || [Command entered:  list]
-|| 	1. Adam Brown  Phone Number: 111111  Email: adam@gmail.com
-|| 	2. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg
-|| 	3. Charlie Dickson  Phone Number: 333333  Email: charlie.d@nus.edu.sg
-|| 	4. Dickson Ee  Phone Number: 444444  Email: dickson@nus.edu.sg
+|| 	1. Adam Brown  Phone Number: 111111  Email: adam@gmail.com Telegram: @adam_brown
+|| 	2. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg Telegram: @BetsyChoo
+|| 	3. Charlie Dickson  Phone Number: 333333  Email: charlie.d@nus.edu.sg Telegram: @charlie_dickson
+|| 	4. Dickson Ee  Phone Number: 444444  Email: dickson@nus.edu.sg Telegram: @dickson_ee
 || 
 || 4 persons found!
 || ===================================================
-|| Enter command: || [Command entered:  add Esther Potato p/555555 e/esther@notreal.potato]
-|| New person added: Esther Potato, Phone: 555555, Email: esther@notreal.potato
+|| Enter command: || [Command entered:  add Esther Potato e/esther@notreal.potato t/@esther_potato p/555555]
+|| New person added: Esther Potato, Phone: 555555, Email: esther@notreal.potato, Telegram: @esther_potato
 || ===================================================
 || Enter command: || [Command entered:  list]
-|| 	1. Adam Brown  Phone Number: 111111  Email: adam@gmail.com
-|| 	2. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg
-|| 	3. Charlie Dickson  Phone Number: 333333  Email: charlie.d@nus.edu.sg
-|| 	4. Dickson Ee  Phone Number: 444444  Email: dickson@nus.edu.sg
-|| 	5. Esther Potato  Phone Number: 555555  Email: esther@notreal.potato
+|| 	1. Adam Brown  Phone Number: 111111  Email: adam@gmail.com Telegram: @adam_brown
+|| 	2. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg Telegram: @BetsyChoo
+|| 	3. Charlie Dickson  Phone Number: 333333  Email: charlie.d@nus.edu.sg Telegram: @charlie_dickson
+|| 	4. Dickson Ee  Phone Number: 444444  Email: dickson@nus.edu.sg Telegram: @dickson_ee
+|| 	5. Esther Potato  Phone Number: 555555  Email: esther@notreal.potato Telegram: @esther_potato
 || 
 || 5 persons found!
+|| ===================================================
+|| Enter command: || [Command entered:  add Fredrick Goh t/@fred_goh p/666666 e/fred@soreal.goh]
+|| New person added: Fredrick Goh, Phone: 666666, Email: fred@soreal.goh, Telegram: @fred_goh
+|| ===================================================
+|| Enter command: || [Command entered:  list]
+|| 	1. Adam Brown  Phone Number: 111111  Email: adam@gmail.com Telegram: @adam_brown
+|| 	2. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg Telegram: @BetsyChoo
+|| 	3. Charlie Dickson  Phone Number: 333333  Email: charlie.d@nus.edu.sg Telegram: @charlie_dickson
+|| 	4. Dickson Ee  Phone Number: 444444  Email: dickson@nus.edu.sg Telegram: @dickson_ee
+|| 	5. Esther Potato  Phone Number: 555555  Email: esther@notreal.potato Telegram: @esther_potato
+|| 	6. Fredrick Goh  Phone Number: 666666  Email: fred@soreal.goh Telegram: @fred_goh
+|| 
+|| 6 persons found!
+|| ===================================================
+|| Enter command: || [Command entered:  add Greg Ho t/@greg_ho e/greg@horeal.ho p/777777]
+|| New person added: Greg Ho, Phone: 777777, Email: greg@horeal.ho, Telegram: @greg_ho
+|| ===================================================
+|| Enter command: || [Command entered:  list]
+|| 	1. Adam Brown  Phone Number: 111111  Email: adam@gmail.com Telegram: @adam_brown
+|| 	2. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg Telegram: @BetsyChoo
+|| 	3. Charlie Dickson  Phone Number: 333333  Email: charlie.d@nus.edu.sg Telegram: @charlie_dickson
+|| 	4. Dickson Ee  Phone Number: 444444  Email: dickson@nus.edu.sg Telegram: @dickson_ee
+|| 	5. Esther Potato  Phone Number: 555555  Email: esther@notreal.potato Telegram: @esther_potato
+|| 	6. Fredrick Goh  Phone Number: 666666  Email: fred@soreal.goh Telegram: @fred_goh
+|| 	7. Greg Ho  Phone Number: 777777  Email: greg@horeal.ho Telegram: @greg_ho
+|| 
+|| 7 persons found!
 || ===================================================
 || Enter command: || [Command entered:  find]
 || 
@@ -188,19 +229,19 @@
 || 0 persons found!
 || ===================================================
 || Enter command: || [Command entered:  find Betsy]
-|| 	1. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg
+|| 	1. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg Telegram: @BetsyChoo
 || 
 || 1 persons found!
 || ===================================================
 || Enter command: || [Command entered:  find Dickson]
-|| 	1. Charlie Dickson  Phone Number: 333333  Email: charlie.d@nus.edu.sg
-|| 	2. Dickson Ee  Phone Number: 444444  Email: dickson@nus.edu.sg
+|| 	1. Charlie Dickson  Phone Number: 333333  Email: charlie.d@nus.edu.sg Telegram: @charlie_dickson
+|| 	2. Dickson Ee  Phone Number: 444444  Email: dickson@nus.edu.sg Telegram: @dickson_ee
 || 
 || 2 persons found!
 || ===================================================
 || Enter command: || [Command entered:  find Charlie Betsy]
-|| 	1. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg
-|| 	2. Charlie Dickson  Phone Number: 333333  Email: charlie.d@nus.edu.sg
+|| 	1. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg Telegram: @BetsyChoo
+|| 	2. Charlie Dickson  Phone Number: 333333  Email: charlie.d@nus.edu.sg Telegram: @charlie_dickson
 || 
 || 2 persons found!
 || ===================================================
@@ -236,37 +277,43 @@
 || The person index provided is invalid
 || ===================================================
 || Enter command: || [Command entered:  delete 2]
-|| Deleted Person: Charlie Dickson  Phone Number: 333333  Email: charlie.d@nus.edu.sg
+|| Deleted Person: Charlie Dickson  Phone Number: 333333  Email: charlie.d@nus.edu.sg Telegram: @charlie_dickson
 || ===================================================
 || Enter command: || [Command entered:  delete 2]
 || Person could not be found in address book
 || ===================================================
 || Enter command: || [Command entered:  list]
-|| 	1. Adam Brown  Phone Number: 111111  Email: adam@gmail.com
-|| 	2. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg
-|| 	3. Dickson Ee  Phone Number: 444444  Email: dickson@nus.edu.sg
-|| 	4. Esther Potato  Phone Number: 555555  Email: esther@notreal.potato
+|| 	1. Adam Brown  Phone Number: 111111  Email: adam@gmail.com Telegram: @adam_brown
+|| 	2. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg Telegram: @BetsyChoo
+|| 	3. Dickson Ee  Phone Number: 444444  Email: dickson@nus.edu.sg Telegram: @dickson_ee
+|| 	4. Esther Potato  Phone Number: 555555  Email: esther@notreal.potato Telegram: @esther_potato
+|| 	5. Fredrick Goh  Phone Number: 666666  Email: fred@soreal.goh Telegram: @fred_goh
+|| 	6. Greg Ho  Phone Number: 777777  Email: greg@horeal.ho Telegram: @greg_ho
 || 
-|| 4 persons found!
+|| 6 persons found!
 || ===================================================
 || Enter command: || [Command entered:  delete 4]
-|| Deleted Person: Esther Potato  Phone Number: 555555  Email: esther@notreal.potato
+|| Deleted Person: Esther Potato  Phone Number: 555555  Email: esther@notreal.potato Telegram: @esther_potato
 || ===================================================
 || Enter command: || [Command entered:  list]
-|| 	1. Adam Brown  Phone Number: 111111  Email: adam@gmail.com
-|| 	2. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg
-|| 	3. Dickson Ee  Phone Number: 444444  Email: dickson@nus.edu.sg
+|| 	1. Adam Brown  Phone Number: 111111  Email: adam@gmail.com Telegram: @adam_brown
+|| 	2. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg Telegram: @BetsyChoo
+|| 	3. Dickson Ee  Phone Number: 444444  Email: dickson@nus.edu.sg Telegram: @dickson_ee
+|| 	4. Fredrick Goh  Phone Number: 666666  Email: fred@soreal.goh Telegram: @fred_goh
+|| 	5. Greg Ho  Phone Number: 777777  Email: greg@horeal.ho Telegram: @greg_ho
 || 
-|| 3 persons found!
+|| 5 persons found!
 || ===================================================
 || Enter command: || [Command entered:  delete 1]
-|| Deleted Person: Adam Brown  Phone Number: 111111  Email: adam@gmail.com
+|| Deleted Person: Adam Brown  Phone Number: 111111  Email: adam@gmail.com Telegram: @adam_brown
 || ===================================================
 || Enter command: || [Command entered:  list]
-|| 	1. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg
-|| 	2. Dickson Ee  Phone Number: 444444  Email: dickson@nus.edu.sg
+|| 	1. Betsy Choo  Phone Number: 222222  Email: benchoo@nus.edu.sg Telegram: @BetsyChoo
+|| 	2. Dickson Ee  Phone Number: 444444  Email: dickson@nus.edu.sg Telegram: @dickson_ee
+|| 	3. Fredrick Goh  Phone Number: 666666  Email: fred@soreal.goh Telegram: @fred_goh
+|| 	4. Greg Ho  Phone Number: 777777  Email: greg@horeal.ho Telegram: @greg_ho
 || 
-|| 2 persons found!
+|| 4 persons found!
 || ===================================================
 || Enter command: || [Command entered:  clear]
 || Address book has been cleared!

--- a/test/input.txt
+++ b/test/input.txt
@@ -19,26 +19,32 @@
 
   # should catch invalid args format
   add wrong args wrong args
-  add Valid Name p/12345 valid@email.butNoPrefix
-  add Valid Name 12345 e/valid@email.butPhonePrefixMissing
+  add Valid Name p/12345 valid@email.butNoPrefix t/@validTele
+  add Valid Name 12345 e/valid@email.butPhonePrefixMissing t/@validTele
+  add Valid Name p/12345 e/valid@email.butTelePrefixMissing @ValidTeleButNoPrefix
   
   # should catch invalid person data
-  add []\[;] p/12345 e/valid@e.mail
-  add Valid Name p/not_numbers e/valid@e.mail
-  add Valid Name p/12345 e/notAnEmail
+  add []\[;] p/12345 e/valid@e.mail t/@validTele
+  add Valid Name p/not_numbers e/valid@e.mail t/@validTele
+  add Valid Name p/12345 e/notAnEmail t/@validTele
+  add Valid Name p/12345 e/valid@e.mail t/invalidTele
 
   # should add correctly
-  add Adam Brown p/111111 e/adam@gmail.com
+  add Adam Brown p/111111 e/adam@gmail.com t/@adam_brown
   list
-  add Betsy Choo p/222222 e/benchoo@nus.edu.sg
+  add Betsy Choo p/222222 e/benchoo@nus.edu.sg t/@BetsyChoo
   list
 
-  # order of phone and email should not matter
-  add Charlie Dickson e/charlie.d@nus.edu.sg p/333333
+  # order of phone, email and tele should not matter
+  add Charlie Dickson p/333333 t/@charlie_dickson e/charlie.d@nus.edu.sg
   list
-  add Dickson Ee e/dickson@nus.edu.sg p/444444
+  add Dickson Ee e/dickson@nus.edu.sg p/444444 t/@dickson_ee
   list
-  add Esther Potato p/555555 e/esther@notreal.potato
+  add Esther Potato e/esther@notreal.potato t/@esther_potato p/555555
+  list
+  add Fredrick Goh t/@fred_goh p/666666 e/fred@soreal.goh
+  list
+  add Greg Ho t/@greg_ho e/greg@horeal.ho p/777777
   list
 
 ##########################################################


### PR DESCRIPTION
For W3.8 Can work with a 1KLoC code base:
Telegram handle has to be included to add a new person. Prefix to add Telegram handle is 't/'. All contacts now store four fields: name, phone number, email address and telegram handle.